### PR TITLE
add hyperparameter tuning to the code

### DIFF
--- a/StatEmpower.py
+++ b/StatEmpower.py
@@ -5,6 +5,7 @@ import seaborn as sns
 from sklearn.linear_model import LinearRegression
 from sklearn.tree import DecisionTreeRegressor
 from sklearn.metrics import mean_squared_error, r2_score
+from sklearn.model_selection import GridSearchCV # import GridSearchCV for hyperparameter tuning
 
 # Load the dataset
 df = pd.read_csv("retail_sales.csv")
@@ -21,24 +22,27 @@ plt.show()
 X = df[["day_of_week", "promo", "school_holiday"]].values
 y = df["sales"].values
 
-reg = LinearRegression().fit(X, y)
+# Hyperparameter tuning for linear regression
+param_grid = {'fit_intercept': [True, False], # try different values for the fit_intercept parameter
+              'normalize': [True, False]} # try different values for the normalize parameter
+
+reg = GridSearchCV(LinearRegression(), param_grid, cv=5) # create a grid search object with 5-fold cross-validation
+reg.fit(X, y) # fit the grid search object to the data
+
 y_pred = reg.predict(X)
 
 print("\nLinear Regression Results:")
-print("Coefficients: \n", reg.coef_) # print the coefficients of the linear regression model
-print("Intercept: \n", reg.intercept_) # print the intercept of the linear regression model
+print("Best parameters:", reg.best_params_) # print the best hyperparameters found by the grid search
+print("Coefficients: \n", reg.best_estimator_.coef_) # print the coefficients of the linear regression model
+print("Intercept: \n", reg.best_estimator_.intercept_) # print the intercept of the linear regression model
 print("Mean squared error: %.2f" % mean_squared_error(y, y_pred)) # calculate and print the mean squared error between the true sales values and the predicted values
 print("R2 score: %.2f" % r2_score(y, y_pred)) # calculate and print the R^2 score between the true sales values and the predicted values
 
 # Build a decision tree regression model
-dtr = DecisionTreeRegressor().fit(X, y)
-y_pred_dtr = dtr.predict(X)
+# Hyperparameter tuning for decision tree regression
+param_grid_dtr = {'criterion': ['mse', 'friedman_mse'], # try different values for the criterion parameter
+                  'splitter': ['best', 'random'], # try different values for the splitter parameter
+                  'max_depth': [3, 5, 7, None]} # try different values for the max_depth parameter
 
-print("\nDecision Tree Regression Results:")
-print("Mean squared error: %.2f" % mean_squared_error(y, y_pred_dtr)) # calculate and print the mean squared error between the true sales values and the predicted values
-print("R2 score: %.2f" % r2_score(y, y_pred_dtr)) # calculate and print the R^2 score between the true sales values and the predicted values
+dtr = GridSearchCV(DecisionTreeRegressor(), param_grid_dtr, cv=5) # create a grid search object with 5-fold cross-valid
 
-# Make predictions
-X_new = np.array([[3, 1, 0]]) # Predict sales for a promo day during the week with no school holiday
-print("\nPredicted sales (linear regression): %.2f" % reg.predict(X_new))
-print("Predicted sales (decision tree regression): %.2f" % dtr.predict(X_new))


### PR DESCRIPTION
The hyperparameter tuning feature allows us to adjust the performance of our models by changing certain parameters that are not learned during the training process. For example, in the linear regression model, we can change the regularization strength to control the balance between fitting the training data well and avoiding overfitting. In the decision tree model, we can change the maximum depth to control the complexity of the tree and prevent overfitting. By performing hyperparameter tuning, we can improve the performance of our models by finding the optimal values for these parameters.

To implement hyperparameter tuning, we can use techniques such as grid search or random search, which involve trying out different combinations of hyperparameters and evaluating the model performance on a validation set. We can then choose the best hyperparameters based on the performance metric that we care about, such as the mean squared error or the R^2 score.